### PR TITLE
feat: scopes 自动列出、Memoria 集成、文档优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # weekly-report-skill
 
-周报生成 Skill，支持各类 Claw 容器（NanoClaw、OpenClaw、QClaw 等）及 Claude Code。从 GitHub 采集 PR 和 Issue 数据，自动生成给 leader 看的工作周报。
+周报生成 Skill，支持各类 Claw 容器（NanoClaw、OpenClaw、QClaw 等）及 Claude Code。从 GitHub 采集 PR 和 Issue 数据，结合 Memoria 工作记忆，自动生成给 leader 看的工作周报。
 
 ## 功能
 
 - 采集指定用户在组织下的 PR（authored + reviewed）和 Issue（involved）
 - PR 自动关联 Issue（通过 body 中的 `fixes #xxx` / `closes #xxx`）
 - 已合并 PR 附带代码变更统计（additions / deletions / changed_files）
+- 集成 Memoria 记忆，自动补充 GitHub 覆盖不到的工作内容
 - 按业务主题自动分类，生成结构化周报
 - 支持对话式补充非 GitHub 内容（会议、评审等）
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,7 +109,7 @@ python ${CLAUDE_SKILL_DIR}/cli.py config --set scopes "org:matrixorigin,org:anot
 
 根据**今天的实际日期**（年月日）推断默认周期。注意使用正确的年份。
 
-- **周四、周五**：本周周报，范围 = 本周一 ~ 今天
+- **周四、周五、周六、周日**：本周周报，范围 = 本周一 ~ 今天
 - **周一、周二、周三**：补上周周报，范围 = 上周一 ~ 上周五
 
 日期格式为 `YYYY-MM-DD`，确保年份正确。
@@ -145,6 +145,7 @@ python ${CLAUDE_SKILL_DIR}/cli.py fetch --since {since} --until {until}
 - **GitHub 数据**：PR 和 Issue 的全量结构化数据（含 body、状态、labels、评论讨论、关联关系等）。这是原始素材，不是周报结构。你需要：
   - **深入阅读内容**：Issue 和 PR 的 body、评论讨论（comments_detail / review_comments / comments）中包含大量上下文——需求背景、讨论结论、决策过程、阻塞原因等。不要只看 title 和 state。
   - **理解逻辑关系**：不要逐条平铺罗列。多个 Issue/PR 之间往往存在内在关联。通过 repo 名称、labels、body 中的互相引用（如 #123、relates to）、共同的关键词等线索，理解数据之间的真实关系，用合理的方式归类组织。
+- **Memoria 记忆**：如果当前环境中有 Memoria（skill 或 MCP），从中获取与工作相关的记忆，自行判断哪些适合纳入周报。没有 Memoria 则跳过。
 - **读者**：用户的 leader
 
 根据这些上下文，自行决定周报的组织方式、板块划分、详略程度。不要使用固定模板。

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,10 +1,12 @@
 # 周报助手使用手册
 
-自动从 GitHub 采集你的 PR 和 Issue 数据，生成一份给 leader 看的工作周报。
+自动从 GitHub 采集你的 PR 和 Issue 数据，结合 Memoria 工作记忆，生成一份给 leader 看的工作周报。
 
 ## 安装
 
-把下面这句话发给你使用的 AI 工具（Claude Code、NanoClaw、OpenClaw、QClaw 等），它会自动帮你完成安装：
+建议优先使用对接了企微的 Claw（如 OpenClaw、QClaw），未来会对接企微的组织架构和数据，体验更好。
+
+把下面这句话发给你使用的 AI 工具（OpenClaw、QClaw、NanoClaw、Claude Code 等），它会自动帮你完成安装：
 
 > 帮我安装这个 skill：https://github.com/matrixorigin/weekly-report-skill
 
@@ -49,16 +51,17 @@
 
 | 今天是 | 生成的周报范围 |
 |--------|--------------|
-| 周四、周五 | 本周一 ~ 今天 |
-| 周一、周二、周三 | 上周一 ~ 上周五 |
+| 周四 ~ 周日 | 本周一 ~ 今天 |
+| 周一 ~ 周三 | 上周一 ~ 上周五 |
 
 也可以指定范围，比如"生成上周的周报"、"生成 3/10 到 3/14 的周报"。
 
-### 采集范围
+### 数据来源
 
-- 你**创建**的 PR
-- 你**评审**的 PR
-- 你**参与**的 Issue（创建、评论、被 assign、被 mention）
+周报的内容来自以下数据源：
+
+- **GitHub** — 你创建的 PR、评审的 PR、参与的 Issue（创建、评论、被 assign、被 mention）
+- **Memoria** — 如果你的环境中有 Memoria，助手会自动从中获取与工作相关的记忆，补充 GitHub 覆盖不到的内容
 
 不需要有关联 PR 的 Issue 也会被采集到。
 


### PR DESCRIPTION
## Summary
- cli.py 新增 `scopes` 子命令，自动获取用户可访问的组织和仓库列表，配置时先列出再让用户选择
- matrixorigin 默认包含，无需用户确认
- 集成 Memoria：有 Memoria skill/MCP 则自动获取工作记忆纳入周报，没有则跳过
- 补充内容强化：用户补充后必须重新输出完整周报
- 日期推断补充周六周日处理（与周四周五一致）
- README 和 USER_GUIDE 安装方式简化，建议优先使用企微 Claw
- 新增 USER_GUIDE.md 用户使用手册

## Test plan
- [ ] 首次配置 scopes 时验证自动列出组织和仓库
- [ ] 有 Memoria 环境下生成周报，验证工作记忆被纳入
- [ ] 无 Memoria 环境下生成周报，验证不受影响
- [ ] 补充内容后验证重新输出完整周报
- [ ] 周六周日生成周报验证日期范围正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)